### PR TITLE
Added esp8266 and esp32 support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 lukas0711
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NewEncoder.h
+++ b/NewEncoder.h
@@ -5,8 +5,8 @@
 #define NEWENCODER_H_
 
 #include <Arduino.h>
-#include "utility\interrupt_pins.h"
-#include "utility\direct_pin_read.h"
+#include "utility/interrupt_pins.h"
+#include "utility/direct_pin_read.h"
 
 #define FULL_PULSE 0
 #define HALF_PULSE 1
@@ -69,296 +69,473 @@ private:
 	static bool attachEncoderInterrupt(uint8_t interruptNumber);
 
 #if CORE_NUM_INTERRUPT > 0
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr00(void) {
 		CALL_MEMBER_FN(_isrTable[0].objectPtr, _isrTable[0].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 1
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr01(void) {
 		CALL_MEMBER_FN(_isrTable[1].objectPtr, _isrTable[1].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 2
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr02(void) {
 		CALL_MEMBER_FN(_isrTable[2].objectPtr, _isrTable[2].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 3
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr03(void) {
 		CALL_MEMBER_FN(_isrTable[3].objectPtr, _isrTable[3].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 4
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr04(void) {
 		CALL_MEMBER_FN(_isrTable[4].objectPtr, _isrTable[4].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 5
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr05(void) {
 		CALL_MEMBER_FN(_isrTable[5].objectPtr, _isrTable[5].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 6
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr06(void) {
 		CALL_MEMBER_FN(_isrTable[6].objectPtr, _isrTable[6].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 7
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr07(void) {
 		CALL_MEMBER_FN(_isrTable[7].objectPtr, _isrTable[7].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 8
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr08(void) {
 		CALL_MEMBER_FN(_isrTable[8].objectPtr, _isrTable[8].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 9
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr09(void) {
 		CALL_MEMBER_FN(_isrTable[9].objectPtr, _isrTable[9].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 10
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr10(void) {
 		CALL_MEMBER_FN(_isrTable[10].objectPtr, _isrTable[10].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 11
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr11(void) {
 		CALL_MEMBER_FN(_isrTable[11].objectPtr, _isrTable[11].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 12
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr12(void) {
 		CALL_MEMBER_FN(_isrTable[12].objectPtr, _isrTable[12].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 13
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr13(void) {
 		CALL_MEMBER_FN(_isrTable[13].objectPtr, _isrTable[13].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 14
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr14(void) {
 		CALL_MEMBER_FN(_isrTable[14].objectPtr, _isrTable[14].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 15
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr15(void) {
 		CALL_MEMBER_FN(_isrTable[15].objectPtr, _isrTable[15].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 16
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr16(void) {
 		CALL_MEMBER_FN(_isrTable[16].objectPtr, _isrTable[16].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 17
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr17(void) {
 		CALL_MEMBER_FN(_isrTable[17].objectPtr, _isrTable[17].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 18
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr18(void) {
 		CALL_MEMBER_FN(_isrTable[18].objectPtr, _isrTable[18].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 19
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr19(void) {
 		CALL_MEMBER_FN(_isrTable[19].objectPtr, _isrTable[19].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 20
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr20(void) {
 		CALL_MEMBER_FN(_isrTable[20].objectPtr, _isrTable[20].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 21
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr21(void) {
 		CALL_MEMBER_FN(_isrTable[21].objectPtr, _isrTable[21].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 22
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr22(void) {
 		CALL_MEMBER_FN(_isrTable[22].objectPtr, _isrTable[22].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 23
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr23(void) {
 		CALL_MEMBER_FN(_isrTable[23].objectPtr, _isrTable[23].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 24
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr24(void) {
 		CALL_MEMBER_FN(_isrTable[24].objectPtr, _isrTable[24].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 25
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr25(void) {
 		CALL_MEMBER_FN(_isrTable[25].objectPtr, _isrTable[25].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 26
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr26(void) {
 		CALL_MEMBER_FN(_isrTable[26].objectPtr, _isrTable[26].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 27
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr27(void) {
 		CALL_MEMBER_FN(_isrTable[27].objectPtr, _isrTable[27].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 28
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr28(void) {
 		CALL_MEMBER_FN(_isrTable[28].objectPtr, _isrTable[28].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 29
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr29(void) {
 		CALL_MEMBER_FN(_isrTable[29].objectPtr, _isrTable[29].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 30
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr30(void) {
 		CALL_MEMBER_FN(_isrTable[30].objectPtr, _isrTable[30].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 31
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr31(void) {
 		CALL_MEMBER_FN(_isrTable[31].objectPtr, _isrTable[31].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 32
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr32(void) {
 		CALL_MEMBER_FN(_isrTable[32].objectPtr, _isrTable[32].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 33
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr33(void) {
 		CALL_MEMBER_FN(_isrTable[33].objectPtr, _isrTable[33].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 34
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr34(void) {
 		CALL_MEMBER_FN(_isrTable[34].objectPtr, _isrTable[34].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 35
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr35(void) {
 		CALL_MEMBER_FN(_isrTable[35].objectPtr, _isrTable[35].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 36
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr36(void) {
 		CALL_MEMBER_FN(_isrTable[36].objectPtr, _isrTable[36].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 37
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr37(void) {
 		CALL_MEMBER_FN(_isrTable[37].objectPtr, _isrTable[37].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 38
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr38(void) {
 		CALL_MEMBER_FN(_isrTable[38].objectPtr, _isrTable[38].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 39
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr39(void) {
 		CALL_MEMBER_FN(_isrTable[39].objectPtr, _isrTable[39].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 40
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr40(void) {
 		CALL_MEMBER_FN(_isrTable[40].objectPtr, _isrTable[40].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 41
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr41(void) {
 		CALL_MEMBER_FN(_isrTable[41].objectPtr, _isrTable[41].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 42
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr42(void) {
 		CALL_MEMBER_FN(_isrTable[42].objectPtr, _isrTable[42].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 43
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr43(void) {
 		CALL_MEMBER_FN(_isrTable[43].objectPtr, _isrTable[43].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 44
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr44(void) {
 		CALL_MEMBER_FN(_isrTable[44].objectPtr, _isrTable[44].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 45
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr45(void) {
 		CALL_MEMBER_FN(_isrTable[45].objectPtr, _isrTable[45].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 46
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr46(void) {
 		CALL_MEMBER_FN(_isrTable[46].objectPtr, _isrTable[46].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 47
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr47(void) {
 		CALL_MEMBER_FN(_isrTable[47].objectPtr, _isrTable[47].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 48
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr48(void) {
 		CALL_MEMBER_FN(_isrTable[48].objectPtr, _isrTable[48].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 49
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr49(void) {
 		CALL_MEMBER_FN(_isrTable[49].objectPtr, _isrTable[49].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 50
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr50(void) {
 		CALL_MEMBER_FN(_isrTable[50].objectPtr, _isrTable[50].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 51
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr51(void) {
 		CALL_MEMBER_FN(_isrTable[51].objectPtr, _isrTable[51].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 52
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr52(void) {
 		CALL_MEMBER_FN(_isrTable[52].objectPtr, _isrTable[52].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 53
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr53(void) {
 		CALL_MEMBER_FN(_isrTable[53].objectPtr, _isrTable[53].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 54
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr54(void) {
 		CALL_MEMBER_FN(_isrTable[54].objectPtr, _isrTable[54].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 55
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr55(void) {
 		CALL_MEMBER_FN(_isrTable[55].objectPtr, _isrTable[55].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 56
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr56(void) {
 		CALL_MEMBER_FN(_isrTable[56].objectPtr, _isrTable[56].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 57
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr57(void) {
 		CALL_MEMBER_FN(_isrTable[57].objectPtr, _isrTable[57].functPtr);
 	}
 #endif
 #if CORE_NUM_INTERRUPT > 58
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+	ICACHE_RAM_ATTR
+#endif
 	static void isr58(void) {
 		CALL_MEMBER_FN(_isrTable[58].objectPtr, _isrTable[58].functPtr);
 	}

--- a/utility/direct_pin_read.h
+++ b/utility/direct_pin_read.h
@@ -1,10 +1,24 @@
 #ifndef direct_pin_read_h_
 #define direct_pin_read_h_
 
-#if defined(__AVR__) || (defined(__arm__) && defined(CORE_TEENSY))
+#if defined(__AVR__)
 
 #define IO_REG_TYPE			uint8_t
 #define PIN_TO_BASEREG(pin)             (portInputRegister(digitalPinToPort(pin)))
+#define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
+#define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
+
+#elif defined(TEENSYDUINO) && (defined(KINETISK) || defined(KINETISL))
+
+#define IO_REG_TYPE			uint8_t
+#define PIN_TO_BASEREG(pin)             (portInputRegister(digitalPinToPort(pin)))
+#define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
+#define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
+
+#elif defined(__IMXRT1052__) || defined(__IMXRT1062__)
+
+#define IO_REG_TYPE			uint32_t
+#define PIN_TO_BASEREG(pin)             (portOutputRegister(pin))
 #define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
 #define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
 
@@ -30,12 +44,27 @@
 #define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
 #define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
 
+/* ESP32  Arduino (https://github.com/espressif/arduino-esp32) */
+#elif defined(ESP32)
+
+#define IO_REG_TYPE			uint32_t
+#define PIN_TO_BASEREG(pin)             (portInputRegister(digitalPinToPort(pin)))
+#define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
+#define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
+
 #elif defined(__SAMD21G18A__)
 
 #define IO_REG_TYPE                     uint32_t
 #define PIN_TO_BASEREG(pin)             portModeRegister(digitalPinToPort(pin))
 #define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
 #define DIRECT_PIN_READ(base, mask)     (((*((base)+8)) & (mask)) ? 1 : 0)
+
+#elif defined(__SAMD51__)
+
+#define IO_REG_TYPE                     uint32_t
+#define PIN_TO_BASEREG(pin)             portInputRegister(digitalPinToPort(pin))
+#define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
+#define DIRECT_PIN_READ(base, mask)     (((*(base)) & (mask)) ? 1 : 0)
 
 #elif defined(RBL_NRF51822)
 

--- a/utility/interrupt_pins.h
+++ b/utility/interrupt_pins.h
@@ -32,7 +32,7 @@
   #endif
 
 // Arduino Uno, Duemilanove, Diecimila, LilyPad, Mini, Fio, etc...
-#elif defined(__AVR_ATmega328P__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega8__)
+#elif defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328PB__) ||defined(__AVR_ATmega168__) || defined(__AVR_ATmega8__)
   #define CORE_NUM_INTERRUPT	2
   #define CORE_INT0_PIN		2
   #define CORE_INT1_PIN		3
@@ -47,6 +47,24 @@
   #define CORE_INT4_PIN		19
   #define CORE_INT5_PIN		18
 
+// Arduino Nano Every, Uno R2 Wifi
+#elif defined(__AVR_ATmega4809__)
+  #define CORE_NUM_INTERRUPT	13
+  #define CORE_INT0_PIN		0
+  #define CORE_INT1_PIN		1
+  #define CORE_INT2_PIN		2
+  #define CORE_INT3_PIN		3
+  #define CORE_INT4_PIN		4
+  #define CORE_INT5_PIN		5
+  #define CORE_INT6_PIN		6
+  #define CORE_INT7_PIN		7
+  #define CORE_INT8_PIN		8
+  #define CORE_INT9_PIN		9
+  #define CORE_INT10_PIN	10
+  #define CORE_INT11_PIN	11
+  #define CORE_INT12_PIN	12
+  #define CORE_INT13_PIN	13
+
 // Arduino Leonardo (untested)
 #elif defined(__AVR_ATmega32U4__) && !defined(CORE_TEENSY)
   #define CORE_NUM_INTERRUPT	5
@@ -56,12 +74,24 @@
   #define CORE_INT3_PIN		1
   #define CORE_INT4_PIN		7
 
-// Sanguino (untested)
-#elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__)
+// Sanguino (untested) and ATmega1284P
+#elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__) || defined(__AVR_ATmega1284P__)
   #define CORE_NUM_INTERRUPT	3
   #define CORE_INT0_PIN		10
   #define CORE_INT1_PIN		11
   #define CORE_INT2_PIN		2
+
+// ATmega32u2 and ATmega32u16 based boards with HoodLoader2
+#elif defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U2__)
+  #define CORE_NUM_INTERRUPT 8
+  #define CORE_INT0_PIN 8
+  #define CORE_INT1_PIN 17
+  #define CORE_INT2_PIN 13
+  #define CORE_INT3_PIN 14
+  #define CORE_INT4_PIN 15
+  #define CORE_INT5_PIN 16
+  #define CORE_INT6_PIN 19
+  #define CORE_INT7_PIN 20
 
 // Chipkit Uno32 - attachInterrupt may not support CHANGE option
 #elif defined(__PIC32MX__) && defined(_BOARD_UNO_)
@@ -85,12 +115,24 @@
 #elif defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)
   #define CORE_NUM_INTERRUPT    1
   #define CORE_INT0_PIN		2
-  
+
+// ATtiny441 ATtiny841
+#elif defined(__AVR_ATtiny441__) || defined(__AVR_ATtiny841__)
+  #define CORE_NUM_INTERRUPT	1
+  #define CORE_INT0_PIN		9
+
 //https://github.com/SpenceKonde/ATTinyCore/blob/master/avr/extras/ATtiny_x313.md
 #elif defined(__AVR_ATtinyX313__)
   #define CORE_NUM_INTERRUPT    2
   #define CORE_INT0_PIN		4
   #define CORE_INT1_PIN		5
+ 
+// Attiny167 same core as abobe
+#elif defined(__AVR_ATtiny167__)
+  #define CORE_NUM_INTERRUPT	2
+  #define CORE_INT0_PIN		14
+  #define CORE_INT1_PIN		3
+
   
 // Arduino Due
 #elif defined(__SAM3X8E__) 
@@ -166,14 +208,49 @@
   #define CORE_INT14_PIN	14
   #define CORE_INT15_PIN	15
 
+// ESP32 (https://github.com/espressif/arduino-esp32)
+#elif defined(ESP32)
+
+  #define CORE_NUM_INTERRUPT    40 
+  #define CORE_INT0_PIN	0
+  #define CORE_INT1_PIN	1
+  #define CORE_INT2_PIN	2
+  #define CORE_INT3_PIN	3
+  #define CORE_INT4_PIN	4
+  #define CORE_INT5_PIN	5
+  // GPIO6-GPIO11 are typically used to interface with the flash memory IC on 
+  // esp32, so we should avoid adding interrupts to these pins.
+  #define CORE_INT12_PIN	12
+  #define CORE_INT13_PIN	13
+  #define CORE_INT14_PIN	14
+  #define CORE_INT15_PIN	15
+  #define CORE_INT16_PIN	16
+  #define CORE_INT17_PIN	17
+  #define CORE_INT18_PIN	18
+  #define CORE_INT19_PIN	19
+  #define CORE_INT21_PIN	21
+  #define CORE_INT22_PIN	22
+  #define CORE_INT23_PIN	23
+  #define CORE_INT25_PIN	25
+  #define CORE_INT26_PIN	26
+  #define CORE_INT27_PIN	27
+  #define CORE_INT32_PIN	32
+  #define CORE_INT33_PIN	33
+  #define CORE_INT34_PIN	34
+  #define CORE_INT35_PIN	35
+  #define CORE_INT36_PIN	36
+  #define CORE_INT39_PIN	39
+
+
 // Arduino Zero - TODO: interrupts do not seem to work
 //                      please help, contribute a fix!
 #elif defined(__SAMD21G18A__)
-  #define CORE_NUM_INTERRUPT	20
+  #define CORE_NUM_INTERRUPT	31
   #define CORE_INT0_PIN		0
   #define CORE_INT1_PIN		1
   #define CORE_INT2_PIN		2
   #define CORE_INT3_PIN		3
+  #define CORE_INT4_PIN		4
   #define CORE_INT5_PIN		5
   #define CORE_INT6_PIN		6
   #define CORE_INT7_PIN		7
@@ -189,6 +266,46 @@
   #define CORE_INT17_PIN	17
   #define CORE_INT18_PIN	18
   #define CORE_INT19_PIN	19
+  #define CORE_INT20_PIN	20
+  #define CORE_INT21_PIN	21
+  #define CORE_INT22_PIN	22
+  #define CORE_INT23_PIN	23
+  #define CORE_INT24_PIN	24
+  #define CORE_INT25_PIN	25
+  #define CORE_INT26_PIN	26
+  #define CORE_INT27_PIN	27
+  #define CORE_INT28_PIN	28
+  #define CORE_INT29_PIN	29
+  #define CORE_INT30_PIN	30
+
+#elif defined(__SAMD51__)
+  #define CORE_NUM_INTERRUPT	26
+  #define CORE_INT0_PIN		0
+  #define CORE_INT1_PIN		1
+  #define CORE_INT2_PIN		2
+  #define CORE_INT3_PIN		3
+  #define CORE_INT4_PIN		4
+  #define CORE_INT5_PIN		5
+  #define CORE_INT6_PIN		6
+  #define CORE_INT7_PIN		7
+  #define CORE_INT8_PIN		8
+  #define CORE_INT9_PIN		9
+  #define CORE_INT10_PIN	10
+  #define CORE_INT11_PIN	11
+  #define CORE_INT12_PIN	12
+  #define CORE_INT13_PIN	13
+  #define CORE_INT14_PIN	14
+  #define CORE_INT15_PIN	15
+  #define CORE_INT16_PIN	16
+  #define CORE_INT17_PIN	17
+  #define CORE_INT18_PIN	18
+  #define CORE_INT19_PIN	19
+  #define CORE_INT20_PIN	20
+  #define CORE_INT21_PIN	21
+  #define CORE_INT22_PIN	22
+  #define CORE_INT23_PIN	23
+  #define CORE_INT24_PIN	24
+  #define CORE_INT25_PIN	25
 
 // Arduino 101
 #elif defined(__arc__)
@@ -212,4 +329,3 @@
 #error "Encoder requires interrupt pins, but this board does not have any :("
 #error "You could try defining ENCODER_DO_NOT_USE_INTERRUPTS as a kludge."
 #endif
-


### PR DESCRIPTION
- Updated the files utility\direct_pin_read.h and utility\interrupt_pins.h to their newest version to get ESP32 support
- Added conditional ICACHE_RAM_ATTR attributes for ESP8266 and ESP32 support. Before the mC used to crash
- Changed slashes in includepaths for compatibility with Mac+Windows