### PR TITLE
Fix the `DIRECT_PIN_READ` for STM32.

### DIFF
--- a/utility/direct_pin_read.h
+++ b/utility/direct_pin_read.h
@@ -99,12 +99,12 @@ IO_REG_TYPE directRead(volatile IO_REG_TYPE *base, IO_REG_TYPE pin)
 }
 #define DIRECT_PIN_READ(base, pin)      directRead(base, pin)
 
-// STM32 ... UNTESTED!!!
+// STM32
 #elif ARDUINO_ARCH_STM32
 #define IO_REG_TYPE PinName
 #define PIN_TO_BASEREG(pin) (nullptr)
 #define PIN_TO_BITMASK(pin) (digitalPinToPinName(pin))
-#define DIRECT_PIN_READ(base, mask) (digitalReadFast(digitalPinToPinName(mask)))
+#define DIRECT_PIN_READ(base, mask) (digitalReadFast(mask))
 
 
 #endif


### PR DESCRIPTION
This is fix is verified with a BluePill.
The same macros for `SAMD51` (and other MCUs) work with STM32 as well, verified.
```
#define IO_REG_TYPE uint32_t
#define PIN_TO_BASEREG(pin) (portInputRegister(digitalPinToPort(pin)))
#define PIN_TO_BITMASK(pin) (digitalPinToBitMask(pin))
#define DIRECT_PIN_READ(base, mask) (((*(base)) & (mask)) ? 1 : 0)
```

p.s.
Thank you so much.
This is the most reliable one among the encoder libraries I've tried.
I'm also working on a fork by adding the support of polling input, I wonder if I can make a PR to merge it to your mainstream.
Would you please take a look?
https://github.com/ghawkgu/NewEncoder-DualMode